### PR TITLE
moving to nuget cpvm not building

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=../CoverageResults/ /p:MergeWith="../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ /p:MergeWith="../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
+      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=../../CoverageResults/ /p:MergeWith="../../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -28,3 +28,10 @@ jobs:
       with:
         name: code-coverage-report
         path: CoverageResults/
+    - uses: codecov/codecov-action@v2
+      with:
+        # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        directory: CoverageResults/
+        flags: unittests # optional
+        name: JsonTranslate.NET # optional
+        verbose: true # optional (default = false)

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,4 +22,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=../CoverageResults/ /p:MergeWith="../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
+      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ /p:MergeWith="./CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage-report
+        path: ./CoverageResults/

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
         path: CoverageResults/
     - uses: codecov/codecov-action@v2
       with:
-        # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
         directory: CoverageResults/
         flags: unittests # optional
         name: JsonTranslate.NET # optional

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ /p:MergeWith="./CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
+      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=../CoverageResults/ /p:MergeWith="../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,9 +22,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=../CoverageResults/ /p:MergeWith="../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
+      run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutput=./CoverageResults/ /p:MergeWith="../CoverageResults/coverage.json" /p:CoverletOutputFormat=\"opencover,json\" -m:1
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2
       with:
         name: code-coverage-report
-        path: ../CoverageResults/
+        path: CoverageResults/

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,4 +27,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: code-coverage-report
-        path: ./CoverageResults/
+        path: ../CoverageResults/

--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+coverlet/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<LangVersion>preview</LangVersion>
 		<Deterministic>true</Deterministic>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<PropertyGroup>
 		<Version>0.0.1</Version>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 	<PropertyGroup>
 		<LangVersion>preview</LangVersion>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<PropertyGroup>
 		<Version>0.0.1</Version>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 	<PropertyGroup>
 		<LangVersion>preview</LangVersion>
-		<Deterministic>true</Deterministic>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
 	<ItemGroup>
 		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
 
-		<PackageVersion Include="Antlr4.Runtime.Standard" Version="4.9.2" />
-		<PackageVersion Include="Antlr4BuildTasks" Version="8.14"/>
+		<!--<PackageVersion Include="Antlr4.Runtime.Standard" Version="4.9.2" />-->
+		<PackageVersion Include="Antlr4BuildTasks" Version="8.15"/>
 
 		<PackageVersion Include="NUnit" Version="3.13.2" />
 		<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,13 @@
+<Project>
+	<ItemGroup>
+		<PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+
+		<PackageVersion Include="Antlr4.Runtime.Standard" Version="4.9.2" />
+		<PackageVersion Include="Antlr4BuildTasks" Version="8.14"/>
+
+		<PackageVersion Include="NUnit" Version="3.13.2" />
+		<PackageVersion Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageVersion Include="NSubstitute" Version="4.2.2" />
+	</ItemGroup>
+</Project>

--- a/JsonTranslate.NET.sln
+++ b/JsonTranslate.NET.sln
@@ -21,6 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		LICENSE = LICENSE
 		nuget.config = nuget.config
 		README.md = README.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![.NET](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/dotnet.yml/badge.svg?branch=main)](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/dotnet.yml)
 [![CodeQL](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/codeql-analysis.yml)
+[![codecov](https://codecov.io/gh/EugeneKrapivin/JsonTranslate.NET/branch/main/graph/badge.svg?token=91KJVNDKWQ)](https://codecov.io/gh/EugeneKrapivin/JsonTranslate.NET)
 
 # JsonTranslate.NET
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![.NET](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/dotnet.yml/badge.svg?branch=main)](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/dotnet.yml)
+[![CodeQL](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/EugeneKrapivin/JsonTranslate.NET/actions/workflows/codeql-analysis.yml)
 
 # JsonTranslate.NET
 

--- a/nuget.config
+++ b/nuget.config
@@ -64,7 +64,7 @@
         Used to specify trusted signers to allow during signature verification.
         See: nuget.exe help trusted-signers
     -->
-    <trustedSigners>
+    <!--<trustedSigners>
         <author name="microsoft">
             <certificate fingerprint="3F9001EA83C560D712C24CF213C3D312CB3BFF51EE89435D3430BD06B5D0EECE" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
             <certificate fingerprint="AA12DA22A49BCE7D5C1AE64CC1F3D892F150DA76140F210ABD2CBFFCA2C18A27" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
@@ -74,5 +74,5 @@
             <certificate fingerprint="5A2901D6ADA3D18260B9C6DFE2133C95D74B9EEF6AE0E5DC334C8454D1477DF4" hashAlgorithm="SHA256" allowUntrustedRoot="false" />
             <owners>microsoft;aspnet;nuget</owners>
         </repository>
-    </trustedSigners>
+    </trustedSigners>-->
 </configuration>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,4 +4,16 @@
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;</TargetFrameworks>
 	</PropertyGroup>
+
+	<PropertyGroup>
+		<IsPackable>true</IsPackable>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="..\..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 </Project>

--- a/src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj
+++ b/src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj
@@ -5,7 +5,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj
+++ b/src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj
@@ -1,17 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<PropertyGroup>
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="..\..\LICENSE">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
 	</ItemGroup>
 </Project>

--- a/src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj
+++ b/src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
 	</ItemGroup>
 </Project>

--- a/src/JsonTranslate.NET.Core.JsonDsl/JsonTranslate.NET.Core.JsonDsl.csproj
+++ b/src/JsonTranslate.NET.Core.JsonDsl/JsonTranslate.NET.Core.JsonDsl.csproj
@@ -1,21 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\JsonTranslate.NET.Core.Abstractions\JsonTranslate.NET.Core.Abstractions.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="..\..\LICENSE">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
 	</ItemGroup>
 </Project>

--- a/src/JsonTranslate.NET.Core.JsonDsl/JsonTranslate.NET.Core.JsonDsl.csproj
+++ b/src/JsonTranslate.NET.Core.JsonDsl/JsonTranslate.NET.Core.JsonDsl.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/JsonTranslate.NET.Core.JsonDsl/JsonTranslate.NET.Core.JsonDsl.csproj
+++ b/src/JsonTranslate.NET.Core.JsonDsl/JsonTranslate.NET.Core.JsonDsl.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/JsonTranslate.NET.Core.JustDsl/JsonTranslate.NET.Core.JustDsl.csproj
+++ b/src/JsonTranslate.NET.Core.JustDsl/JsonTranslate.NET.Core.JustDsl.csproj
@@ -1,8 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\JsonTranslate.NET.Core.Abstractions\JsonTranslate.NET.Core.Abstractions.csproj" />
@@ -23,11 +19,4 @@
 	<PropertyGroup Condition="'$(Platform)'=='AnyCPU'">
 		<NoWarn>3021</NoWarn>
 	</PropertyGroup>
-
-	<ItemGroup>
-		<None Include="..\..\LICENSE">
-			<Pack>True</Pack>
-			<PackagePath></PackagePath>
-		</None>
-	</ItemGroup>
 </Project>

--- a/src/JsonTranslate.NET.Core.JustDsl/JsonTranslate.NET.Core.JustDsl.csproj
+++ b/src/JsonTranslate.NET.Core.JustDsl/JsonTranslate.NET.Core.JustDsl.csproj
@@ -5,8 +5,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Antlr4.Runtime.Standard" />
-		<PackageReference Include="Antlr4BuildTasks">
+		<PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2"/>
+		<PackageReference Include="Antlr4BuildTasks" Version="8.14">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/src/JsonTranslate.NET.Core.JustDsl/JsonTranslate.NET.Core.JustDsl.csproj
+++ b/src/JsonTranslate.NET.Core.JustDsl/JsonTranslate.NET.Core.JustDsl.csproj
@@ -9,8 +9,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Antlr4.Runtime.Standard" Version="4.9.2" />
-		<PackageReference Include="Antlr4BuildTasks" Version="8.14">
+		<PackageReference Include="Antlr4.Runtime.Standard" />
+		<PackageReference Include="Antlr4BuildTasks">
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/src/JsonTranslate.NET.Core/JsonTranslate.NET.Core.csproj
+++ b/src/JsonTranslate.NET.Core/JsonTranslate.NET.Core.csproj
@@ -1,9 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<IsPackable>true</IsPackable>
-		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
@@ -14,12 +9,5 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="JsonTranslate.NET.Transformer.UnitTests" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Include="..\..\LICENSE">
-	    <Pack>True</Pack>
-	    <PackagePath></PackagePath>
-	  </None>
 	</ItemGroup>
 </Project>

--- a/src/JsonTranslate.NET.Core/JsonTranslate.NET.Core.csproj
+++ b/src/JsonTranslate.NET.Core/JsonTranslate.NET.Core.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/JsonTranslate.NET.Core/JsonTranslate.NET.Core.csproj
+++ b/src/JsonTranslate.NET.Core/JsonTranslate.NET.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.JsonDsl.UnitTests/JsonTranslate.NET.JsonDsl.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.JsonDsl.UnitTests/JsonTranslate.NET.JsonDsl.UnitTests.csproj
@@ -6,15 +6,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
-
 
 	<ItemGroup>
 		<ProjectReference Include="../../src/JsonTranslate.NET.Core.Abstractions/JsonTranslate.NET.Core.Abstractions.csproj" />

--- a/tests/JsonTranslate.NET.JsonDsl.UnitTests/JsonTranslate.NET.JsonDsl.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.JsonDsl.UnitTests/JsonTranslate.NET.JsonDsl.UnitTests.csproj
@@ -6,13 +6,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="NUnit" />
+		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 

--- a/tests/JsonTranslate.NET.JsonDsl.UnitTests/JsonTranslate.NET.JsonDsl.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.JsonDsl.UnitTests/JsonTranslate.NET.JsonDsl.UnitTests.csproj
@@ -9,6 +9,14 @@
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.msbuild" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.JustDsl.UnitTests/JsonTranslate.NET.JustDsl.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.JustDsl.UnitTests/JsonTranslate.NET.JustDsl.UnitTests.csproj
@@ -6,13 +6,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="NUnit" />
+		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.JustDsl.UnitTests/JsonTranslate.NET.JustDsl.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.JustDsl.UnitTests/JsonTranslate.NET.JustDsl.UnitTests.csproj
@@ -6,13 +6,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0"/>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.JustDsl.UnitTests/JsonTranslate.NET.JustDsl.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.JustDsl.UnitTests/JsonTranslate.NET.JustDsl.UnitTests.csproj
@@ -9,6 +9,14 @@
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.msbuild" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.Transformer.UnitTests/JsonTranslate.NET.Transformer.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.Transformer.UnitTests/JsonTranslate.NET.Transformer.UnitTests.csproj
@@ -6,12 +6,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" />
-		<PackageReference Include="NUnit3TestAdapter" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="NUnit" Version="3.13.2" />
+		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0"/>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
 
-		<PackageReference Include="NSubstitute" />
-		<PackageReference Include="Newtonsoft.Json" />
+		<PackageReference Include="NSubstitute" Version="4.2.2"/>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.Transformer.UnitTests/JsonTranslate.NET.Transformer.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.Transformer.UnitTests/JsonTranslate.NET.Transformer.UnitTests.csproj
@@ -6,12 +6,12 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="3.13.2" />
-		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+		<PackageReference Include="NUnit" />
+		<PackageReference Include="NUnit3TestAdapter" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
 
-		<PackageReference Include="NSubstitute" Version="4.2.2" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="NSubstitute" />
+		<PackageReference Include="Newtonsoft.Json" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/JsonTranslate.NET.Transformer.UnitTests/JsonTranslate.NET.Transformer.UnitTests.csproj
+++ b/tests/JsonTranslate.NET.Transformer.UnitTests/JsonTranslate.NET.Transformer.UnitTests.csproj
@@ -9,8 +9,17 @@
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0"/>
-
+		<PackageReference Include="coverlet.collector" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.msbuild" Version="3.1.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 		<PackageReference Include="NSubstitute" Version="4.2.2"/>
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
 	</ItemGroup>
 


### PR DESCRIPTION
moving the package version management to [NuGet CPVM](https://github.com/NuGet/Home/wiki/Centrally-managing-NuGet-package-versions) to allow better control over package version management.